### PR TITLE
Add UploadedFile cleanup to fix EntityManager::flush errors

### DIFF
--- a/EventListener/ObjectUploadSubscriber.php
+++ b/EventListener/ObjectUploadSubscriber.php
@@ -167,8 +167,11 @@ class ObjectUploadSubscriber implements EventSubscriber
             $fileFieldProperty = lcfirst($camelizedFieldName);
             if (isset($fileUploads[$fileFieldProperty])) {
                 $getter = 'get'.$camelizedFieldName;
+                $setter = 'set'.$camelizedFieldName.'Upload';
 
                 $fileUploads[$fileFieldProperty]->move($this->getFilePath($objectName, $fileFieldConfiguration['name']), $object->$getter());
+
+                $object->$setter(null);
             }
         }
     }

--- a/Model/UploadTrait.php
+++ b/Model/UploadTrait.php
@@ -53,7 +53,10 @@ trait UploadTrait
     {
         $propertyName = $this->getFileUploadPropertyName();
 
-        $this->fileUploads[$propertyName] = $file;
+        unset($this->fileUploads[$propertyName]);
+        if ($file instanceof UploadedFile) {
+            $this->fileUploads[$propertyName] = $file;
+        }
     }
 
     /**


### PR DESCRIPTION
Calling flush on the entity manager twice causes errors due to the temporary file in the `UploadedFile` instance already being moved during the first flush call.

This PR fixes this by cleaning up the `UploadedFile` instances after processing them.
